### PR TITLE
use CompilerAccessor instead of reflection

### DIFF
--- a/src/com/google/javascript/jscomp/CompilerAccessor.java
+++ b/src/com/google/javascript/jscomp/CompilerAccessor.java
@@ -1,0 +1,7 @@
+package com.google.javascript.jscomp;
+
+public class CompilerAccessor {
+  public static CompilerInput getSynthesizedExternsInputAtEnd(Compiler compiler) {
+    return compiler.getSynthesizedExternsInputAtEnd();
+  }
+}

--- a/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
+++ b/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
@@ -90,7 +90,7 @@ public class ReactCompilerPassTest {
       // Private methods should be invokable.
       "ReactDOM.$render$(React.$createElement$(React.$createClass$({" +
         "$render$:function(){return React.$createElement$(\"div\")}," +
-        "$privateMethod1_$:function($a$$2$$){window.$foo$=123+$a$$2$$}," +
+        "$privateMethod1_$:function($a$jscomp$2$$){window.$foo$=123+$a$jscomp$2$$}," +
         "$privateMethod2_$:function(){this.$privateMethod1_$(1)}" +
       "})),document.body);");
     testError(


### PR DESCRIPTION
I am hoping you might consider this pull request, which proposes to use a strategy similar to that employed in
https://github.com/bolinfest/plovr/blob/master/src/com/google/javascript/jscomp/PlovrCompilerOptions.java

where you make class that exists in the same package as that protected method.  In this case, we can expose the protected method via static call:

```java
package com.google.javascript.jscomp;

public class CompilerAccessor {
  public static CompilerInput getSynthesizedExternsInputAtEnd(Compiler compiler) {
    return compiler.getSynthesizedExternsInputAtEnd();
  }
}
```

then your use of that would look like:

```java
  private void addExterns() {
    CompilerInput externsInput = CompilerAccessor.getSynthesizedExternsInputAtEnd(compiler);
    addExternModule("React", "ReactModule", externsInput);
    addExternModule("ReactDOM", "ReactDOMModule", externsInput);
    addExternModule("ReactDOMServer", "ReactDOMServerModule", externsInput);
    compiler.reportCodeChange();
  }
```

This makes the usage of getSynthesizedExternsInput a little more declarative than reflection's imperative nature.  Then, in the future, should the compiler change this method name, the error will be at compile time, instead of at runtime.

Then only downside I can think of in doing it this way, rather than reflection, would be if you are using this in an environment that requires [sealed jar files](https://docs.oracle.com/javase/tutorial/deployment/jar/sealman.html).  In that case you could simply move the compiler accessor class into the sealed jar I guess.

Also, update lib to include latest released closure-compiler from
https://developers.google.com/closure/compiler/#how-do-i-start

this necessitated updating one of the unit tests.

lib/closure-compiler-20160911.jar -> lib/compiler-v20161024.jar