### PR TITLE
Add command line runner to mimic closure-compiler

### DIFF
--- a/src/info/persistent/react/jscomp/ReactCommandLineRunner.java
+++ b/src/info/persistent/react/jscomp/ReactCommandLineRunner.java
@@ -1,0 +1,40 @@
+package info.persistent.react.jscomp;
+
+import com.google.javascript.jscomp.CommandLineRunner;
+import com.google.javascript.jscomp.Compiler;
+import com.google.javascript.jscomp.CompilerOptions;
+import com.google.javascript.jscomp.CustomPassExecutionTime;
+
+import java.io.IOException;
+
+
+public class ReactCommandLineRunner extends CommandLineRunner {
+    ReactCommandLineRunner(String[] args) {
+        super(args);
+    }
+
+    @Override
+    protected CompilerOptions createOptions() {
+        Compiler compiler = this.getCompiler();
+
+        ReactCompilerPass.Options passOptions = new ReactCompilerPass.Options();
+        passOptions.propTypesTypeChecking = true;
+        ReactCompilerPass compilerPass = new ReactCompilerPass(compiler, passOptions);
+
+        CompilerOptions options = super.createOptions();
+        options.addCustomPass(CustomPassExecutionTime.BEFORE_CHECKS, compilerPass);
+        options.addWarningsGuard(new ReactWarningsGuard(compiler, compilerPass));
+
+        return options;
+    }
+
+    public static void main(String[] args) {
+        ReactCommandLineRunner runner = new ReactCommandLineRunner(args);
+        if (runner.shouldRunCompiler()) {
+            runner.run();
+        }
+        if (runner.hasErrors()) {
+            System.exit(-1);
+        }
+    }
+}

--- a/tools/closure-compiler
+++ b/tools/closure-compiler
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+buildfile="$scriptdir"/../build.xml
+builddir="$scriptdir"/../build
+
+if [ "$(ant -f "$buildfile" jar)" -ne 0 ]; then
+  echo "Could not recompile"
+  exit 1
+fi
+
+libdir="$scriptdir"/../lib
+
+compilerjar=""
+for jar in "$libdir"/closure-compiler-*.jar; do
+  compilerjar=$jar
+done
+
+guavajar=""
+for jar in "$libdir"/guava-*.jar; do
+  guavajar=$jar
+done
+
+exec java -classpath "$compilerjar:$guavajar:$builddir/react-closure-compiler.jar" info.persistent.react.jscomp.ReactCommandLineRunner "$@"


### PR DESCRIPTION
This command line script is to play with react-closure-compiler.

ReactCommandLineRunner simply extends the original closure-compiler's
CommandLineRunner adding custom ReactCompilerPass and
ReactWarningsGuard.