### PR TITLE
Upgrade Closure Compiler to v20181028

### DIFF
--- a/src/info/persistent/react/jscomp/PropTypesExtractor.java
+++ b/src/info/persistent/react/jscomp/PropTypesExtractor.java
@@ -1,6 +1,7 @@
 package info.persistent.react.jscomp;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;

--- a/src/info/persistent/react/jscomp/ReactCompilerPass.java
+++ b/src/info/persistent/react/jscomp/ReactCompilerPass.java
@@ -139,7 +139,7 @@ public class ReactCompilerPass implements NodeTraversal.Callback,
       lastOutputForTests = new CodePrinter.Builder(root)
           .setPrettyPrint(true)
           .setOutputTypes(true)
-          .setTypeRegistry(compiler.getTypeIRegistry())
+          .setTypeRegistry(compiler.getTypeRegistry())
           .build();
     } else {
       lastOutputForTests = null;

--- a/src/info/persistent/react/jscomp/types.js
+++ b/src/info/persistent/react/jscomp/types.js
@@ -228,15 +228,13 @@ ReactComponent.prototype.componentWillUnmount = function() {};
 function ReactFragment() {}
 
 /**
- * @typedef {boolean|number|string|ReactElement|ReactFragment}
+ * @typedef {boolean|number|string|null|undefined|ReactElement|ReactFragment}
  */
 var ReactChild;
 
 /**
  * @typedef {
- *   ReactChild|
- *   Array.<boolean>|Array.<number>|Array.<string>|Array.<ReactElement>|
- *   Object.<boolean>|Object.<number>|Object.<string>|Object.<ReactElement>
+ *   ReactChild|Array.<ReactChild>|undefined
  * }
  */
 var ReactChildrenArgument;

--- a/src/info/persistent/react/jscomp/types.js
+++ b/src/info/persistent/react/jscomp/types.js
@@ -234,7 +234,10 @@ var ReactChild;
 
 /**
  * @typedef {
- *   ReactChild|Array.<ReactChild>|undefined
+ *   ReactChild|
+ *   Array.<ReactChild>|
+ *   Object.<ReactChild>|
+ *   undefined
  * }
  */
 var ReactChildrenArgument;

--- a/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
+++ b/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
@@ -1469,7 +1469,7 @@ public class ReactCompilerPassTest {
       lastOutput += "Final compiler output:\n" + new CodePrinter.Builder(compiler.getRoot())
           .setPrettyPrint(true)
           .setOutputTypes(true)
-          .setTypeRegistry(compiler.getTypeIRegistry())
+          .setTypeRegistry(compiler.getTypeRegistry())
           .build() +
           "\n";
     }

--- a/test/info/persistent/react/jscomp/ReactWarningsGuardTest.java
+++ b/test/info/persistent/react/jscomp/ReactWarningsGuardTest.java
@@ -74,7 +74,8 @@ public class ReactWarningsGuardTest {
         SourceFile.fromCode(
           "externs",
           "/** @constructor */ function Element() {};\n" +
-          "/** @constructor */ function Event() {};"));
+          "/** @constructor */ function Event() {};\n"+
+          "/** @constructor */ function Error() {};"));
     Result result = compiler.compile(externs, inputs, options);
     assertFalse(result.success);
     assertEquals(1, result.errors.length);


### PR DESCRIPTION
The type interfaces are gone in favor of direct references to the type
implementations.

Updated React type defs a little since the new version of GCC now
realizes that a child in createElement can end up as null or undefined
and undefined was missing in the type definition.