### PR TITLE
Use the object literal for PropTypesExtractor

### DIFF
--- a/src/info/persistent/react/jscomp/PropTypesExtractor.java
+++ b/src/info/persistent/react/jscomp/PropTypesExtractor.java
@@ -179,8 +179,7 @@ class PropTypesExtractor {
   }
 
   public static boolean canExtractPropTypes(Node propTypesNode) {
-    return propTypesNode.hasOneChild() &&
-        propTypesNode.getFirstChild().isObjectLit();
+    return propTypesNode.isObjectLit();
   }
 
   /**
@@ -189,8 +188,7 @@ class PropTypesExtractor {
    * were added.
    */
   public static void cleanUpPropTypesWhenNotChecking(Node propTypesNode) {
-    Node propTypesObjectLitNode = propTypesNode.getFirstChild();
-    for (Node propTypeKeyNode : propTypesObjectLitNode.children()) {
+    for (Node propTypeKeyNode : propTypesNode.children()) {
       if (propTypeKeyNode.getJSDocInfo() != null) {
         JSDocInfo propTypeJsDoc = propTypeKeyNode.getJSDocInfo();
         if (propTypeJsDoc.hasType()) {
@@ -220,7 +218,7 @@ class PropTypesExtractor {
       propsWithDefaultValues = Collections.emptySet();
     }
 
-    Node propTypesObjectLitNode = propTypesNode.getFirstChild();
+    Node propTypesObjectLitNode = propTypesNode;
     props = Lists.newArrayListWithCapacity(
         propTypesObjectLitNode.getChildCount());
     canBeCreatedWithNoProps = mixedInPropTypes.values().stream().allMatch(


### PR DESCRIPTION
We used to store the KEY but with upcoming changes to support using ES6
class syntax for React components we no longer have a key.