### PR TITLE
Switch SymbolTable to a LinkedHashMap

### DIFF
--- a/src/info/persistent/react/jscomp/SymbolTable.java
+++ b/src/info/persistent/react/jscomp/SymbolTable.java
@@ -15,7 +15,8 @@ import java.util.Map;
 import java.util.function.Function;
 
 class SymbolTable<V> {
-  private final Map<String, V> map = Maps.newHashMap();
+  // Need insertion order iteration
+  private final Map<String, V> map = Maps.newLinkedHashMap();
 
   public Collection<V> values() {
     return map.values();

--- a/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
+++ b/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
@@ -1040,6 +1040,28 @@ public class ReactCompilerPassTest {
       "");
   }
 
+  @Test public void testMixinOnExportClass() {
+    // The real error here was that SymbolTable uses a HashMap but we need an
+    // Map that iterates in th insertion order.
+    testNoError(
+      REACT_SUPPORT_CODE +
+      "class TestMixin extends React.Component {" +
+        "/** @return {string} */" +
+        "d1() {" +
+          "return \"M12\";" +
+        "}" +
+      "}" +
+      "ReactSupport.declareMixin(TestMixin);" +
+      "export class AddCommentIcon extends React.Component {" +
+        "/** @override */" +
+        "render() {" +
+          "this.d1();" +
+          "return null;" +
+        "}" +
+      "}" +
+      "ReactSupport.mixin(AddCommentIcon, TestMixin);");
+  }
+
   @Test public void testMixinImplementsClass() {
     test(
         REACT_SUPPORT_CODE +


### PR DESCRIPTION
We need to iterate over the entries in insertion order. This is
important for class out of bounds data because we need to handle a mixin
before the class that depends on it.