### PR TITLE
Declare optional astract mixin methods on target

### DIFF
--- a/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
+++ b/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
@@ -1024,9 +1024,8 @@ public class ReactCompilerPassTest {
       "class Mixin extends React.Component {}" +
       "ReactSupport.declareMixin(Mixin);" +
       "/**\n" +
-      " * @param {T} param1\n" +
-      " * @return {T}\n" +
-      " * @template T\n" +
+      " * @param {string} param1\n" +
+      " * @return {string}\n" +
       " */" +
       "Mixin.mixinAbstractMethod;" +
       "class Comp extends React.Component {" +
@@ -1061,6 +1060,56 @@ public class ReactCompilerPassTest {
       "}" +
       "ReactSupport.mixin(AddCommentIcon, TestMixin);");
   }
+
+  @Test public void testMixinOptionalAbstractMethodClass() {
+    testNoError(
+      REACT_SUPPORT_CODE +
+      "class Mixin extends React.Component {" +
+        "/** @return {number} */" +
+        "method() {" +
+          "if (this.optionalAbstract) {" +
+            "return this.optionalAbstract();" +
+          "}"+
+          "return 42;" +
+        "}" +
+      "}" +
+      "ReactSupport.declareMixin(Mixin);" +
+      "/** @return {number} */" +
+      "Mixin.optionalAbstract;" +
+      "class Comp extends React.Component {" +
+        "/** @override */" +
+        "render() {" +
+          "this.method();" +
+          "return null;" +
+        "}" +
+      "}" +
+      "ReactSupport.mixin(Comp, Mixin);");
+    testNoError(
+      REACT_SUPPORT_CODE +
+      "class Mixin extends React.Component {" +
+        "/** @return {number} */" +
+        "method() {" +
+          "if (this.optionalAbstract) {" +
+            "return this.optionalAbstract();" +
+          "}"+
+          "return 42;" +
+        "}" +
+      "}" +
+      "ReactSupport.declareMixin(Mixin);" +
+      "/** @return {number} */" +
+      "Mixin.optionalAbstract;" +
+      "class Comp extends React.Component {" +
+        "/** @override */" +
+        "render() {" +
+          "this.method();" +
+          "return null;" +
+        "}" +
+        "optionalAbstract() {" +
+          "return 42;" +
+        "}" +
+      "}" +
+      "ReactSupport.mixin(Comp, Mixin);");
+    }
 
   @Test public void testMixinImplementsClass() {
     test(


### PR DESCRIPTION
When a mixin has an optional abstract method we need to tell the class
about it.

```js
class Mixin extends React.Component {}
ReactSupport.declareMixin(Mixin);
/**
 * @param {a} p
 * @return {b}
 */
Mixin.optionalAbstract;
class Comp extends React.Component {}
ReactSupport.mixin(Comp, Mixin);
```

we generate code that looks like:

```js
/** @type {(function(a): b)|undefined} */
Comp.prototype.optionalAbstract;
```

Without this we end up getting a `Unexpected errors:
JSC_INTERFACE_METHOD_NOT_IMPLEMENTED. property optionalAbstract on
interface MixinInterface is not implemented by type Comp`