### PR TITLE
Make the validators static properties of the class

### DIFF
--- a/src/info/persistent/react/jscomp/PropTypesExtractor.java
+++ b/src/info/persistent/react/jscomp/PropTypesExtractor.java
@@ -671,7 +671,7 @@ class PropTypesExtractor {
       jsDocBuilder.recordReturnType(
           new JSTypeExpression(childrenPropTypeNode, sourceFileName));
       childrenValidatorFuncNode.setJSDocInfo(jsDocBuilder.build());
-      childrenValidatorFuncNode.useSourceInfoIfMissingFromForTree(insertionPoint);
+      childrenValidatorAssignmentNode.useSourceInfoIfMissingFromForTree(insertionPoint);
       insertionPoint.getParent().addChildAfter(
         childrenValidatorAssignmentNode, insertionPoint);
       insertionPoint = childrenValidatorAssignmentNode;

--- a/src/info/persistent/react/jscomp/ReactCompilerPass.java
+++ b/src/info/persistent/react/jscomp/ReactCompilerPass.java
@@ -719,7 +719,9 @@ public class ReactCompilerPass implements NodeTraversal.Callback,
             contextTypesNode, null, typeName, typeName,
             mixedInContextTypes, compiler, true);
         extractor.extract();
-        extractor.insert(insertionNode, data.addModuleExports);
+        if (!options.optimizeForSize) {
+          extractor.insert(insertionNode);
+        }
 
         maybeAddNoCollapse(contextTypesNode);
       }
@@ -739,7 +741,9 @@ public class ReactCompilerPass implements NodeTraversal.Callback,
             propTypesNode, defaultPropsNode, typeName, typeName,
             mixedInPropTypes, compiler);
         extractor.extract();
-        extractor.insert(insertionNode, data.addModuleExports);
+        if (!options.optimizeForSize) {
+          extractor.insert(insertionNode);
+        }
         extractor.addToComponentMethods(data.componentMethodKeys);
         propTypesExtractorsByName.put(classNameNode, extractor, moduleExportInput);
 
@@ -1147,13 +1151,15 @@ public class ReactCompilerPass implements NodeTraversal.Callback,
 
     if (contextTypesNode != null &&
         PropTypesExtractor.canExtractPropTypes(contextTypesNode)) {
-      if (options.propTypesTypeChecking) {
+      if (options.propTypesTypeChecking){
         // TODO(arv): mixedInPropTypes below should be mixedInContextTypes.
         PropTypesExtractor extractor = new PropTypesExtractor(
             contextTypesNode, null, typeName, interfaceTypeName,
             mixedInPropTypes, compiler, true);
         extractor.extract();
-        extractor.insert(typesInsertionPoint, addModuleExports);
+        if (!options.optimizeForSize) {
+          extractor.insert(typesInsertionPoint);
+        }
       } else {
         PropTypesExtractor.cleanUpPropTypesWhenNotChecking(contextTypesNode);
       }
@@ -1172,7 +1178,9 @@ public class ReactCompilerPass implements NodeTraversal.Callback,
             propTypesNode, defaultPropsNode, typeName, interfaceTypeName,
             mixedInPropTypes, compiler);
         extractor.extract();
-        extractor.insert(typesInsertionPoint, addModuleExports);
+        if (!options.optimizeForSize) {
+          extractor.insert(typesInsertionPoint);
+        }
         if (createFuncName.equals("React.createClass")) {
           extractor.addToComponentMethods(componentMethodKeys);
         }

--- a/src/info/persistent/react/jscomp/ReactCompilerPass.java
+++ b/src/info/persistent/react/jscomp/ReactCompilerPass.java
@@ -1151,7 +1151,7 @@ public class ReactCompilerPass implements NodeTraversal.Callback,
 
     if (contextTypesNode != null &&
         PropTypesExtractor.canExtractPropTypes(contextTypesNode)) {
-      if (options.propTypesTypeChecking){
+      if (options.propTypesTypeChecking) {
         // TODO(arv): mixedInPropTypes below should be mixedInContextTypes.
         PropTypesExtractor extractor = new PropTypesExtractor(
             contextTypesNode, null, typeName, interfaceTypeName,

--- a/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
+++ b/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
@@ -1995,12 +1995,16 @@ public class ReactCompilerPassTest {
         "}" +
       "});" +
       "ReactDOM.render(React.createElement(Comp), document.body);",
-      "ReactDOM.render(React.createElement(React.createClass({" +
+      "var $Comp$$=React.createClass({" +
         "propTypes:{$aProp$:React.PropTypes.string}," +
         "render:function(){" +
           "return React.createElement(\"div\",null,this.props.$aProp$)" +
         "}" +
-      "})),document.body);");
+      "});" +
+      "$Comp$$.$PropsValidator$=function($props$jscomp$5$$){" +
+        "return $props$jscomp$5$$" +
+      "};" +
+      "ReactDOM.render(React.createElement($Comp$$),document.body);");
     // isRequired variant
     test(
       "window.foo=React.PropTypes.string.isRequired;",
@@ -3075,15 +3079,22 @@ public class ReactCompilerPassTest {
           "}" +
       "});" +
       "ReactDOM.render(React.createElement(Comp), document.body);",
-      "ReactDOM.render(React.createElement(React.createClass({" +
+      "var $Comp$$=React.createClass({" +
         "propTypes:{" +
           "children:React.PropTypes.element.isRequired" +
         "}," +
         "render:function(){" +
           "return React.createElement(" +
-              "\"div\",null,React.Children.only(this.props.children))" +
+            "\"div\",null,React.Children.only(this.props.children))" +
         "}" +
-      "})),document.body);");
+      "});" +
+      "$Comp$$.$PropsValidator$=function($props$jscomp$5$$){" +
+        "return $props$jscomp$5$$" +
+      "};" +
+      "$Comp$$.$ChildrenValidator$=function($children$jscomp$7$$){" +
+        "return $children$jscomp$7$$" +
+      "};" +
+      "ReactDOM.render(React.createElement($Comp$$),document.body);");
   }
 
   @Test public void testChildrenClass() {


### PR DESCRIPTION
This way we do not need to manipulate imports and exports to include the
validators.

For React.createClass this means that we end up with code that cannot be
stripped by Closure Compiler unless optimizeForSize is true.