### PR TITLE
Make sure we include parameters in mixin interface methods

### DIFF
--- a/src/info/persistent/react/jscomp/ReactCompilerPass.java
+++ b/src/info/persistent/react/jscomp/ReactCompilerPass.java
@@ -1906,9 +1906,10 @@ public class ReactCompilerPass implements NodeTraversal.Callback,
         if (key.getJSDocInfo() == null || key.getJSDocInfo().getVisibility() != Visibility.PRIVATE) {
           // Create methods on the interface too
           Node prototypeNode = reactMixinInterfacePrototypePropsByName.get(scope, nameNode);
+          Node paramListNode = key.getFirstChild().getSecondChild().cloneTree();
           Node methodNode = IR.memberFunctionDef(
               keyName,
-              IR.function(IR.name(""), IR.paramList(), IR.block()));
+              IR.function(IR.name(""), paramListNode, IR.block()));
           JSDocInfoBuilder methodJSDocInfoBuilder = newJsDocInfoBuilderForNode(key);
           methodNode.setJSDocInfo(methodJSDocInfoBuilder.build());
           prototypeNode.addChildToBack(methodNode);

--- a/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
+++ b/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
@@ -1233,6 +1233,52 @@ public class ReactCompilerPassTest {
       "");
   }
 
+  @Test public void testMixinsParameters() {
+    testNoError(
+      "const TestMixin = React.createMixin({" +
+        "/**" +
+        " * @param {string} p1\n" +
+        " * @param {number} p2\n" +
+        " * @return {string}" +
+        " */" +
+        "method(p1, p2) {" +
+          "return p1 + p2;" +
+        "}" +
+      "});" +
+      "const AddCommentIcon = React.createClass({" +
+        "mixins: [TestMixin]," +
+        "/** @override */" +
+        "render() {" +
+          "this.method(\"a\", 1);" +
+          "return null;" +
+        "}" +
+      "})");
+  }
+
+  @Test public void testMixinsParametersClass() {
+    testNoError(
+      REACT_SUPPORT_CODE +
+      "class TestMixin extends React.Component {" +
+        "/**" +
+        " * @param {string} p1\n" +
+        " * @param {number} p2\n" +
+        " * @return {string}" +
+        " */" +
+        "method(p1, p2) {" +
+          "return p1 + p2;" +
+        "}" +
+      "}" +
+      "ReactSupport.declareMixin(TestMixin);" +
+      "class AddCommentIcon extends React.Component {" +
+        "/** @override */" +
+        "render() {" +
+          "this.method(\"a\", 1);" +
+          "return null;" +
+        "}" +
+      "}" +
+      "ReactSupport.mixin(AddCommentIcon, TestMixin);");
+  }
+
   @Test public void testMixinsRepeatedMethodsClass() {
     test(
       REACT_SUPPORT_CODE +
@@ -2205,7 +2251,6 @@ public class ReactCompilerPassTest {
       passOptions,
       null);
   }
-
 
   @Test public void testOptimizeForSizeClass() {
     ReactCompilerPass.Options passOptions =


### PR DESCRIPTION
For a mixin we generate an interface. We were not setting the parameters
in the methods. Like this

```js
class Mixin extends React.Component {
    /** @param {number} x */
    method(x) {}
}
ReactSupport.declareMixin(Mixin);
```

generated:

```js
/** @interface */
function MixinInterface() {}
/** @param {number} x */
MixinInterface.prototype.method = function() {}
```

The last line above needs to be:

```js
MixinInterface.prototype.method = function(x) {}
```

or `x` gets marked as optional which leads to issues when overriding.