### PR TITLE
Change strategy for optional abstract mixin methods

### DIFF
--- a/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
+++ b/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
@@ -1243,6 +1243,36 @@ public class ReactCompilerPassTest {
       "ReactSupport.mixin(Comp, Mixin);");
   }
 
+  @Test public void testMixinOptionalAbstractMethodModulesClass() {
+    testNoError(
+      REACT_SUPPORT_CODE +
+      "export class Mixin extends React.Component {" +
+        "/** @return {number} */" +
+        "method() {" +
+          "if (this.optionalAbstract) {" +
+            "return this.optionalAbstract();" +
+          "}"+
+          "return 42;" +
+        "}" +
+      "}" +
+      "ReactSupport.declareMixin(Mixin);" +
+      "/** @return {T} */" +
+      "Mixin.optionalAbstract;" +
+      "/** @typedef {number} */" +
+      "let T;" +
+      FILE_SEPARATOR +
+      REACT_SUPPORT_CODE +
+      "import {Mixin} from \"./file1.js\";"+ 
+      "class Comp extends React.Component {" +
+        "/** @override */" +
+        "render() {" +
+          "this.method();" +
+          "return null;" +
+        "}" +
+      "}" +
+      "ReactSupport.mixin(Comp, Mixin);");
+  }
+
   @Test public void testMixinImplementsClass() {
     test(
         REACT_SUPPORT_CODE +

--- a/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
+++ b/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
@@ -1243,6 +1243,29 @@ public class ReactCompilerPassTest {
       "ReactSupport.mixin(Comp, Mixin);");
   }
 
+  @Test public void testMixinOptionalAbstractMethodsNotUsed() {
+    testNoError(
+      REACT_SUPPORT_CODE +
+      "export const Mixin = React.createMixin({});" +
+      "/**" +
+      " * @param {string} x" +
+      " * @return {number}" +
+      " */" +
+      "Mixin.foo;");
+  }
+
+  @Test public void testMixinOptionalAbstractMethodsNotUsedClass() {
+    testNoError(
+      REACT_SUPPORT_CODE +
+      "export class Mixin extends React.Component {}" +
+      "ReactSupport.declareMixin(Mixin);" +
+      "/**" +
+      " * @param {string} x" +
+      " * @return {number}" +
+      " */" +
+      "Mixin.foo;");
+  }
+
   @Test public void testMixinOptionalAbstractMethodModulesClass() {
     testNoError(
       REACT_SUPPORT_CODE +


### PR DESCRIPTION
Given:

```js
class Mixin extends React.Component {
  method() {
    if (this.optionalAbstract) {
      this.optionalAbstract(42);
    }
}
ReactSupport.declareMixin(Mixin);
/**
 * @param {number} x
 */
Mixin.optionalAbstract;

class Comp extends React.Component {}
ReactSupport.mixin(Comp, Mixin);
```

We now generate something along the lines of:

```js
/** @interface */
function MixinInterface() {}
MixinInterface.prototype {
    method: function() {},
};
/**
 * @param {number} x
 */
Mixin$$optionalAbstract;
/** @type {typeof Mixin$$optionalAbstract|undefined} */
MixinInterface.prototype.optionalAbstract;

class Mixin extends React.Component {
  method() {
    if (this.optionalAbstract) {
      this.optionalAbstract(42);
    }
}
/** @type {typeof Mixin$$optionalAbstract|undefined} */
Mixin.prototype.optionalAbstract;
ReactSupport.declareMixin(Mixin);
/**
 * @param {number} x
 */
Mixin.optionalAbstract;

/** @implements {MixinInterface} */
class Comp extends React.Component {}
ReactSupport.mixin(Comp, Mixin);
/** @type {typeof MixinInterface.prototype.optionalAbstract} */
Comp.prototype.optionalAbstract;
```