### PR TITLE
Add an export to work around JSC_UNUSED_LOCAL_ASSIGNMENT

### DIFF
--- a/src/info/persistent/react/jscomp/ReactCompilerPass.java
+++ b/src/info/persistent/react/jscomp/ReactCompilerPass.java
@@ -2201,6 +2201,9 @@ public class ReactCompilerPass implements NodeTraversal.Callback,
       JSDocInfoBuilder builder = JSDocInfoBuilder.copyFrom(info);
       String baseName = nameNode.getQualifiedName() + "$$" + entry.getKey();
       Node decl = NodeUtil.newQNameDeclaration(compiler, baseName, null, builder.build());
+      if (outOfBoundsData.addModuleExports) {
+        decl = IR.export(decl);
+      }
       insertNode.getParent().addChildAfter(decl, insertNode);
 
       // Mixin.prototype.foo


### PR DESCRIPTION
The value of the var for `Mixin$$foo` is never read. It is only added to
allow us to reference the type.

Follow up to 518f893f84b2b658323a69c4159698051f47bd80