### PR TITLE
Export dummy function if in module

### DIFF
--- a/src/info/persistent/react/jscomp/ReactCompilerPass.java
+++ b/src/info/persistent/react/jscomp/ReactCompilerPass.java
@@ -2201,7 +2201,9 @@ public class ReactCompilerPass implements NodeTraversal.Callback,
       JSDocInfoBuilder builder = JSDocInfoBuilder.copyFrom(info);
       String baseName = nameNode.getQualifiedName() + "$$" + entry.getKey();
       Node decl = NodeUtil.newQNameDeclaration(compiler, baseName, null, builder.build());
-      if (outOfBoundsData.addModuleExports) {
+      // Export dummy function to prevent JSC from complaining that the value is
+      // never read.
+      if (outOfBoundsData.scope.isModuleScope()) {
         decl = IR.export(decl);
       }
       insertNode.getParent().addChildAfter(decl, insertNode);

--- a/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
+++ b/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
@@ -1252,12 +1252,31 @@ public class ReactCompilerPassTest {
       " * @return {number}" +
       " */" +
       "Mixin.foo;");
+    testNoError(
+      REACT_SUPPORT_CODE +
+      "export {};" +
+      "const Mixin = React.createMixin({});" +
+      "/**" +
+      " * @param {string} x" +
+      " * @return {number}" +
+      " */" +
+      "Mixin.foo;");
   }
 
   @Test public void testMixinOptionalAbstractMethodsNotUsedClass() {
     testNoError(
       REACT_SUPPORT_CODE +
       "export class Mixin extends React.Component {}" +
+      "ReactSupport.declareMixin(Mixin);" +
+      "/**" +
+      " * @param {string} x" +
+      " * @return {number}" +
+      " */" +
+      "Mixin.foo;");
+    testNoError(
+      REACT_SUPPORT_CODE +
+      "export {};" +
+      "class Mixin extends React.Component {}" +
       "ReactSupport.declareMixin(Mixin);" +
       "/**" +
       " * @param {string} x" +


### PR DESCRIPTION
It doesn't matter if the Mixin is exported or not. Always export the
dummy function so that JSC does not complain that the value is never
read.

Folllow up to 7dd70d9b09948c591ae6423fd801a1a3433dfd5e