### PR TITLE
Add @implements to mixin classes too

### DIFF
--- a/src/com/google/javascript/rhino/JSDocInfoAccessor.java
+++ b/src/com/google/javascript/rhino/JSDocInfoAccessor.java
@@ -11,4 +11,8 @@ public class JSDocInfoAccessor {
   public static void setJSDocExport(JSDocInfo jsDocInfo, boolean export) {
     jsDocInfo.setExport(export);
   }
+
+  public static void setJSDocOverride(JSDocInfo jsDocInfo, boolean override) {
+    jsDocInfo.setOverride(override);
+  }
 }

--- a/src/info/persistent/react/jscomp/ReactCompilerPass.java
+++ b/src/info/persistent/react/jscomp/ReactCompilerPass.java
@@ -986,6 +986,13 @@ public class ReactCompilerPass implements NodeTraversal.Callback,
     List<Node> componentMethodKeys = Lists.newArrayList();
     for (Node key : specNode.children()) {
       String keyName = key.getString();
+
+      // @override are not allowed on object literals
+      JSDocInfo info = NodeUtil.getBestJSDocInfo(key);
+      if (info != null) {
+        JSDocInfoAccessor.setJSDocOverride(info, false);
+      }
+
       if (keyName.equals("mixins")) {
         List<Node> mixinNameNodes = addMixinsToType(
             t.getScope(),
@@ -1235,7 +1242,8 @@ public class ReactCompilerPass implements NodeTraversal.Callback,
     synthesizeExterns(exportedNames, typeName);
   }
 
-  private void gatherAbstractMethodsAndPropsFromMixin(Scope scope, Map<String, JSDocInfo> abstractMethodJsDocsByName,
+  private void gatherAbstractMethodsAndPropsFromMixin(Scope scope,
+      Map<String, JSDocInfo> abstractMethodJsDocsByName,
       Map<Node, PropTypesExtractor> mixedInPropTypes, List<Node> mixinNameNodes) {
     for (Node mixinNameNode : mixinNameNodes) {
       if (mixinAbstractMethodJsDocsByName.containsName(scope, mixinNameNode)) {
@@ -1336,7 +1344,7 @@ public class ReactCompilerPass implements NodeTraversal.Callback,
         methodName,
         abstractFuncNode,
         interfacePrototypeProps,
-        prototypeObjectLiteral,        
+        prototypeObjectLiteral,
         getPropNode.getJSDocInfo());
 
     ClassOutOfBoundsData data = classOutOfBoundsMap.get(t.getScope(), mixinNameNode);

--- a/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
+++ b/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
@@ -4081,6 +4081,40 @@ public class ReactCompilerPassTest {
       "let x;");
   }
 
+  @Test public void testMixinOverrideMixin() {
+    testNoError(
+      REACT_SUPPORT_CODE +
+      "const MixinA = React.createMixin({});" +
+      "/** @param {string} s */" +
+      "MixinA.method;" +
+      "const MixinB = React.createMixin({" +
+        "mixins: [MixinA]," +
+        "/**\n" +
+        " * @param {string} s\n" +
+        " * @override\n" +
+        " */" +
+        "method(s) {}," +
+      "});");
+  }
+
+  @Test public void testMixinOverrideMixinClass() {
+    testNoError(
+      REACT_SUPPORT_CODE +
+      "class MixinA extends React.Component {}" +
+      "ReactSupport.declareMixin(MixinA);" +
+      "/** @param {string} s */" +
+      "MixinA.method;" +
+      "class MixinB extends React.Component {" +
+        "/**\n" +
+        " * @param {string} s\n" +
+        " * @override\n" +
+        " */" +
+        "method(s) {}" +
+      "}" +
+      "ReactSupport.declareMixin(MixinB);" +
+      "ReactSupport.mixin(MixinB, MixinA);");
+}
+
   private static void test(String inputJs, String expectedJs) {
     test(inputJs, expectedJs, null, null);
   }


### PR DESCRIPTION
If a mixin class has a mixin then the mixin class should have an
`@implements` for the interface backing the mixin. For example:

```js
class MixinB extends React.Component {
  /**
   * @param {string} s
   * @override
   */
  method(s) {}
}
ReactSupport.declareMixin(MixinB);
ReactSupport.mixin(MixinB, MixinA);
```

Should end up with:

```js
/** @implements {MixinAInterface} */
class MixinB extends React.Component {
```