### PR TITLE
Keep contextTypes and childContextTypes

### DIFF
--- a/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
+++ b/test/info/persistent/react/jscomp/ReactCompilerPassTest.java
@@ -2559,6 +2559,7 @@ public class ReactCompilerPassTest {
       "Comp.propTypes = {aProp: React.PropTypes.string};" +
       "Comp.defaultProps = {aProp: \"hi\"};" +
       "Comp.contextTypes = {aContext: React.PropTypes.number};" +
+      "Comp.childContextTypes = {aChildContext: React.PropTypes.number};" +
       "ReactDOM.render(React.createElement(Comp), document.body);",
       "class $Comp$$module$src$file1$$ extends $React$Component$${" +
         "render(){" +
@@ -2566,6 +2567,8 @@ public class ReactCompilerPassTest {
         "}" +
       "}" +
       "$Comp$$module$src$file1$$.defaultProps={$aProp$:\"hi\"};" +
+      "$Comp$$module$src$file1$$.contextTypes={$aContext$:$React$PropTypes$$.number};" +
+      "$Comp$$module$src$file1$$.childContextTypes={$aChildContext$:$React$PropTypes$$.number};" +
       "ReactDOM.render($React$createElement$$($Comp$$module$src$file1$$),document.body);",
       passOptions,
       null);


### PR DESCRIPTION
Make sure that JSC does not think these are dead code which happens when
it collapses them to Comp$contextTypes. By tagging them with
`@nocollapse` JSC keeps these as static properties.

The only one we can remove is propTypes which is not checked in
production mode anyway.